### PR TITLE
sdm845-common: wifi: Enable 40MHz channel width in 2.4GHz band

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -587,7 +587,7 @@ ignore_fw_reg_offload_ind=1
 g_sta_sap_scc_on_dfs_chan=1
 
 #Configures Channel Bonding in 24 GHz
-gChannelBondingMode24GHz=0
+gChannelBondingMode24GHz=1
 
 gActiveUcBpfMode=0
 gActiveMcBcBpfMode=1


### PR DESCRIPTION
Enabling 40MHz channel width improves WiFi performance when connected to a WiFi network with 40MHz channel width.

I changed this manually for quite a while now (in /vendor/etc/wifi/WCNSS_qcom_cfg.ini) and it worked just fine, improving the performance with my 2.4GHz 40MHz WiFi network considerably.